### PR TITLE
stop cron updte

### DIFF
--- a/.github/workflows/createdata.yml
+++ b/.github/workflows/createdata.yml
@@ -3,8 +3,11 @@
 
 name: Create data.json
 on:
-  schedule:
-    - cron: "0 */4 * * *"
+  push:
+    branches:
+      - main
+  # schedule:
+    # - cron: "0 */4 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
main yamaanshi covid site have already stopped and update have not accepted. so stop this scraping cron and change the trigger push to main branch